### PR TITLE
Fixes Hayai for C++11

### DIFF
--- a/src/hayai-benchmarker.hpp
+++ b/src/hayai-benchmarker.hpp
@@ -79,12 +79,12 @@ namespace Hayai
                     double(deviated) - double(average);                 \
                                                                         \
                 PAD(description <<                                      \
-                    deviated << " "unit" (" <<                          \
+                    deviated << " " << unit << " (" <<                  \
                     (deviated < average ?                               \
                      Console::TextRed :                                 \
                      Console::TextGreen) <<                             \
                     (deviated > average ? "+" : "") <<                  \
-                    _d_ << " "unit" / " <<                              \
+                    _d_ << " " << unit << " / " <<                      \
                     (deviated > average ? "+" : "") <<                  \
                     (_d_ * 100.0 / average) << " %" <<                  \
                     Console::TextDefault << ")");                       \
@@ -99,12 +99,12 @@ namespace Hayai
                     double(deviated) - double(average);                 \
                                                                         \
                 PAD(description <<                                      \
-                    deviated << " "unit" (" <<                          \
+                    deviated << " " << unit << " (" <<                  \
                     (deviated > average ?                               \
                      Console::TextRed :                                 \
                      Console::TextGreen) <<                             \
                     (deviated > average ? "+" : "") <<                  \
-                    _d_ << " "unit" / " <<                              \
+                    _d_ << " " << unit << " / " <<                      \
                     (deviated > average ? "+" : "") <<                  \
                     (_d_ * 100.0 / average) << " %" <<                  \
                     Console::TextDefault << ")");                       \


### PR DESCRIPTION
Hi,

this fix allows Hayai to compile with -std=c++11 in both clang++-3.2 and g++-4.7. Please apply it whenever you have the time.

best,

Bruno.
