### PR TITLE
First stab at hayai-config.cmake setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,59 @@
 project(hayai)
 cmake_minimum_required(VERSION 2.4)
 
+# Offer the user the choice of overriding the installation directories
+set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
+set(INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
+set(INSTALL_INCLUDE_DIR include CACHE PATH
+  "Installation directory for header files")
+if(WIN32 AND NOT CYGWIN)
+  set(DEF_INSTALL_CMAKE_DIR CMake)
+else()
+  set(DEF_INSTALL_CMAKE_DIR lib/CMake/hayai)
+endif()
+set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
+  "Installation directory for CMake files")
+
+# Make relative paths absolute (needed later on)
+foreach(p LIB BIN INCLUDE CMAKE)
+  set(var INSTALL_${p}_DIR)
+  if(NOT IS_ABSOLUTE "${${var}}")
+    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  endif()
+endforeach()
+
 # Sub projects
 add_subdirectory(src)
 add_subdirectory(sample)
+
+# Export targets and package
+
+# Add all targets to the build-tree export set
+export(TARGETS hayai_main hayai_sample
+  FILE "${PROJECT_BINARY_DIR}/hayai-targets.cmake")
+
+# Export the package for use from the build-tree
+# (this registers the build-tree with a global CMake-registry)
+export(PACKAGE hayai)
+
+# Create the hayai-config.cmake
+file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}"
+   "${INSTALL_INCLUDE_DIR}")
+# ... for the build tree
+set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src" "${PROJECT_BINARY_DIR}")
+configure_file(hayai-config.cmake.in
+  "${PROJECT_BINARY_DIR}/hayai-config.cmake" @ONLY)
+# ... for the install tree
+set(CONF_INCLUDE_DIRS "\${HAYAI_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+configure_file(hayai-config.cmake.in
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hayai-config.cmake" @ONLY)
+
+# Install the hayai-config.cmake
+install(FILES
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hayai-config.cmake"
+  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+
+# Install the export set for use with the install-tree
+install(EXPORT hayai-targets DESTINATION
+  "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+

--- a/hayai-config.cmake.in
+++ b/hayai-config.cmake.in
@@ -1,0 +1,16 @@
+# - Config file for the hayai package
+# It defines the following variables
+#  HAYAI_INCLUDE_DIRS - include directories for hayai
+#  HAYAI_LIBRARIES    - libraries to link against
+#  HAYAI_EXECUTABLE   - the sample executable
+
+# Compute paths
+get_filename_component(HAYAI_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(HAYAI_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+
+# Our library dependencies (contains definitions for IMPORTED targets)
+include("${HAYAI_CMAKE_DIR}/hayai-targets.cmake")
+
+# These are IMPORTED targets created by hayai-targets.cmake
+set(HAYAI_LIBRARIES hayai_main)
+set(HAYAI_EXECUTABLE hayai_sample)

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -2,13 +2,19 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/src
 )
 
-add_executable(sample
+add_executable(hayai_sample
   delivery_man_benchmark.cpp
   delivery_man_benchmark_with_fixture.cpp
   delivery_man_benchmark_parameterized.cpp
   delivery_man_benchmark_parameterized_with_fixture.cpp
 )
 
-target_link_libraries(sample
+target_link_libraries(hayai_sample
   hayai_main
 )
+
+install(TARGETS hayai_sample
+  # IMPORTANT: Add the executable to the "export-set"
+  EXPORT hayai-targets 
+  RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+  COMPONENT bin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,27 @@
+file(GLOB hayai_headers
+  hayai_benchmarker.hpp
+  hayai_console.hpp
+  hayai_console_outputter.hpp
+  hayai_fixture.hpp
+  hayai.hpp
+  hayai_outputter.hpp
+)
+
 add_library(hayai_main
   hayai_posix_main.cpp
+)
+
+set_target_properties(hayai_main
+  PROPERTIES
+  PUBLIC_HEADER "${hayai_headers}"
+)
+
+install(TARGETS hayai_main
+  # IMPORTANT: Add the library to the "export-set"
+  EXPORT hayai-targets
+  RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT bin
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
+  PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/hayai"
+  COMPONENT dev
 )


### PR DESCRIPTION
This is attempt to provide CMake `find_package` config mode for hayai project
The configuration is based on the official tutorials:
http://www.cmake.org/Wiki/CMake/Tutorials/How_to_create_a_ProjectConfig.cmake_file
http://www.cmake.org/Wiki/CMake/Tutorials/Exporting_and_Importing_Targets

There is one little details that may need to be improved:
either move public headers to `${PROJECT_SOURCE_DIR}include/hayai` or tweak `${PROJECT_SOURCE_DIR}/src` in `CONF_INCLUDE_DIRS` variable, so the include paths are set properly while importing targets directly from the build directory (a nice CMake feature, by the way).

Generally, I think it would be good to install and use buried headers in hayai sources as well as in client programs, like this:

```
#include <hayai/hayai.hpp>
```
