### PR TITLE
XML support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,16 @@
 project(hayai)
 cmake_minimum_required(VERSION 2.4)
 
+option(USE_XML "Use XML output" OFF)
+
+if (USE_XML)
+    FIND_PACKAGE(LibXml2 REQUIRED)
+    ADD_DEFINITIONS(-D__HAYAI_USE_XML)
+    INCLUDE_DIRECTORIES(SYSTEM "${LIBXML2_INCLUDE_DIR}")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LIBXML2_DEFINITIONS}")
+    LINK_DIRECTORIES("${LIBXML2_LIBRARIES}")
+endif()
+
 # Sub projects
 add_subdirectory(src)
 add_subdirectory(sample)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_library(hayai_main
   hayai_posix_main.cpp
 )
+
+if (USE_XML)
+    target_link_libraries(hayai_main xml2)
+endif()

--- a/src/hayai.hpp
+++ b/src/hayai.hpp
@@ -3,6 +3,7 @@
 #include "hayai_default_test_factory.hpp"
 #include "hayai_fixture.hpp"
 #include "hayai_console_outputter.hpp"
+#include "hayai_xml_outputter.hpp"
 
 #ifndef __HAYAI
 

--- a/src/hayai_posix_main.cpp
+++ b/src/hayai_posix_main.cpp
@@ -2,9 +2,13 @@
 
 int main()
 {
-    hayai::ConsoleOutputter consoleOutputter;
+#ifdef __HAYAI_USE_XML
+    hayai::XmlOutputter outputter;
+#else
+	hayai::ConsoleOutputter outputter;
+#endif
 
-    hayai::Benchmarker::AddOutputter(consoleOutputter);
+    hayai::Benchmarker::AddOutputter(outputter);
     hayai::Benchmarker::RunAllTests();
     return 0;
 }

--- a/src/hayai_posix_main.cpp
+++ b/src/hayai_posix_main.cpp
@@ -1,11 +1,11 @@
 #include "hayai.hpp"
 
-int main()
+int main(const char** args, int argv)
 {
 #ifdef __HAYAI_USE_XML
     hayai::XmlOutputter outputter;
 #else
-	hayai::ConsoleOutputter outputter;
+    hayai::ConsoleOutputter outputter;
 #endif
 
     hayai::Benchmarker::AddOutputter(outputter);

--- a/src/hayai_xml_outputter.hpp
+++ b/src/hayai_xml_outputter.hpp
@@ -35,6 +35,12 @@ namespace hayai
             xmlNewProp(node, BAD_CAST name, xmlRepr);
             xmlFree(xmlRepr);
         }
+
+        template <typename NameType>
+        static xmlNodePtr AddChild(xmlNodePtr node, NameType name)
+        {
+            return xmlNewChild(node, NULL, BAD_CAST name, NULL);
+        }
    
     public:
 
@@ -53,12 +59,12 @@ namespace hayai
         }
 
         void BeginTest(const std::string& fixtureName,
-                               const std::string& testName,
-                               const std::string& parameters,
-                               const std::size_t& runsCount,
-                               const std::size_t& iterationsCount)
+                       const std::string& testName,
+                       const std::string& parameters,
+                       const std::size_t& runsCount,
+                       const std::size_t& iterationsCount)
         {
-            testNode = xmlNewChild(rootNode, NULL, BAD_CAST "hayai::test", NULL);
+            testNode = AddChild(rootNode, "hayai::test");
 
             AddProperty(testNode, "fixtureName", fixtureName);
             AddProperty(testNode, "testName", testName);
@@ -69,9 +75,9 @@ namespace hayai
 
 
         void EndTest(const std::string& fixtureName,
-                             const std::string& testName,
-                             const std::string& parameters,
-                             const TestResult& result)
+                     const std::string& testName,
+                     const std::string& parameters,
+                     const TestResult& result)
         {           
             AddProperty(testNode, "timeTotal", result.TimeTotal() / 1000000.0);
             AddProperty(testNode, "runTimeAverage", result.RunTimeAverage() / 1000.0);

--- a/src/hayai_xml_outputter.hpp
+++ b/src/hayai_xml_outputter.hpp
@@ -1,0 +1,104 @@
+#ifndef __HAYAI_XMLOUTPUTTER
+#define __HAYAI_XMLOUTPUTTER
+#include "hayai_outputter.hpp"
+#include "hayai_console.hpp"
+
+#ifdef __HAYAI_USE_XML 
+#include <libxml/tree.h>
+#include <libxml/xmlstring.h>
+#include <libxml/xmlmemory.h>
+#include <sstream>
+
+namespace hayai
+{
+        
+    /// Xml outputter.
+    /// Prints the result to standard output in XML format.
+    class XmlOutputter
+        :   public Outputter
+    {
+
+    private:
+
+        template <typename T>
+        static xmlChar* ToXmlString(const T& value)
+        {
+            std::stringstream strs;
+            strs << value;
+            return xmlCharStrdup(strs.str().c_str());
+        }
+
+        template <typename NameType, typename ValueType>
+        static void AddProperty(xmlNodePtr node, NameType name, const ValueType& value)
+        {         
+            xmlChar* xmlRepr = ToXmlString(value);
+            xmlNewProp(node, BAD_CAST name, xmlRepr);
+            xmlFree(xmlRepr);
+        }
+   
+    public:
+
+        void Begin(const std::size_t& benchmarksCount)
+        {
+            document = xmlNewDoc(BAD_CAST "1.0");
+            rootNode = xmlNewNode(NULL, BAD_CAST "hayai::tests");
+            xmlDocSetRootElement(document, rootNode);
+        }
+
+        void End(const std::size_t& benchmarksCount)
+        {
+            xmlSaveFormatFileEnc("-", document, "UTF-8", 1);
+            xmlFreeDoc(document);
+            xmlCleanupParser();
+        }
+
+        void BeginTest(const std::string& fixtureName,
+                               const std::string& testName,
+                               const std::string& parameters,
+                               const std::size_t& runsCount,
+                               const std::size_t& iterationsCount)
+        {
+            testNode = xmlNewChild(rootNode, NULL, BAD_CAST "hayai::test", NULL);
+
+            AddProperty(testNode, "fixtureName", ToXmlString(fixtureName));
+            AddProperty(testNode, "testName", ToXmlString(testName));
+            AddProperty(testNode, "parameters", ToXmlString(parameters));
+            AddProperty(testNode, "runsCount", ToXmlString(runsCount));
+            AddProperty(testNode, "iterationsCount", ToXmlString(iterationsCount));
+        }
+
+
+        void EndTest(const std::string& fixtureName,
+                             const std::string& testName,
+                             const std::string& parameters,
+                             const TestResult& result)
+        {           
+            AddProperty(testNode, "timeTotal", result.TimeTotal() / 1000000.0);
+            AddProperty(testNode, "runTimeAverage", result.RunTimeAverage() / 1000.0);
+
+            AddProperty(testNode, "runTimeMinimum", result.RunTimeMinimum() / 1000.0);
+            AddProperty(testNode, "runTimeMaximum", result.RunTimeMaximum() / 1000.0);
+            AddProperty(testNode, "runTimeAverage", result.RunTimeAverage() / 1000.0);
+
+            AddProperty(testNode, "runsPerSecondMinimum", result.RunsPerSecondMinimum());
+            AddProperty(testNode, "runsPerSecondMaximum", result.RunsPerSecondMaximum());
+            AddProperty(testNode, "runsPerSecondAverage", result.RunsPerSecondAverage());
+
+            AddProperty(testNode, "iterationTimeMinimum", result.IterationTimeMinimum());
+            AddProperty(testNode, "iterationTimeMaximum", result.IterationTimeMaximum());
+            AddProperty(testNode, "iterationTimeAverage", result.IterationTimeAverage());
+
+            AddProperty(testNode, "iterationsPerSecondMinimum", result.IterationsPerSecondMinimum());
+            AddProperty(testNode, "iterationsPerSecondMaximum", result.IterationsPerSecondMaximum());
+            AddProperty(testNode, "iterationsPerSecondAverage", result.IterationsPerSecondAverage());
+        }
+
+    private:
+        xmlDocPtr document;
+        xmlNodePtr rootNode;
+        xmlNodePtr testNode;
+    };
+        
+};
+#endif
+#endif

--- a/src/hayai_xml_outputter.hpp
+++ b/src/hayai_xml_outputter.hpp
@@ -60,11 +60,11 @@ namespace hayai
         {
             testNode = xmlNewChild(rootNode, NULL, BAD_CAST "hayai::test", NULL);
 
-            AddProperty(testNode, "fixtureName", ToXmlString(fixtureName));
-            AddProperty(testNode, "testName", ToXmlString(testName));
-            AddProperty(testNode, "parameters", ToXmlString(parameters));
-            AddProperty(testNode, "runsCount", ToXmlString(runsCount));
-            AddProperty(testNode, "iterationsCount", ToXmlString(iterationsCount));
+            AddProperty(testNode, "fixtureName", fixtureName);
+            AddProperty(testNode, "testName", testName);
+            AddProperty(testNode, "parameters", parameters);
+            AddProperty(testNode, "runsCount", runsCount);
+            AddProperty(testNode, "iterationsCount", iterationsCount);
         }
 
 


### PR DESCRIPTION
This PR adds XML support fo hayai with libxml.

Additional CMake routines are added. 

Valgrind report:
``` 
==18702== HEAP SUMMARY:
==18702==     in use at exit: 0 bytes in 0 blocks
==18702==   total heap usage: 1,276 allocs, 1,276 frees, 153,116 bytes allocated
```