### PR TITLE
Fix miscalculated benchmark durations

### DIFF
--- a/src/hayai_clock.hpp
+++ b/src/hayai_clock.hpp
@@ -278,7 +278,7 @@ namespace hayai
             else
                 timeDiff.tv_nsec = endTime.tv_nsec - startTime.tv_nsec;
 
-            return static_cast<uint64_t>(timeDiff.tv_sec * 1000000000L +
+            return static_cast<uint64_t>(timeDiff.tv_sec * 1000000000LL +
                                          timeDiff.tv_nsec);
         }
 


### PR DESCRIPTION
This commit replaces a 32-bit long literal with a 64-bit long literal for converting test durations from seconds to nanoseconds. The previous implementation would lead to wrong results when having large test times that exceeded 4294 milliseconds (which, in nanoseconds, is the maximum duration fitting into a 32-bit long).