### PR TITLE
Statistical Values in the Test Result, Console and JSON Output

### DIFF
--- a/src/hayai_console_outputter.hpp
+++ b/src/hayai_console_outputter.hpp
@@ -208,7 +208,7 @@ namespace hayai
 
             PAD("");
             PAD("Average performance: " <<
-                result.RunsPerSecondAverage() << " runs/s " );
+                result.RunsPerSecondAverage() << " runs/s");
             PAD_DEVIATION("Best performance: ",
                           result.RunsPerSecondMaximum(),
                           result.RunsPerSecondAverage(),
@@ -249,30 +249,28 @@ namespace hayai
 		<< "(" << Console::TextCyan << " "
 		<< result.IterationTimeQuartile1() / 1000.0 << " | "
 		<< result.IterationTimeQuartile3() / 1000.0 << " "
-		<< Console::TextDefault << ")"
-		);
+		<< Console::TextDefault << ")");
 
             _stream << std::setprecision(5);
 
             PAD("");
             PAD("Average performance: " <<
                 result.IterationsPerSecondAverage() <<
-                " iter/s " );
+                " iterations/s");
             PAD_DEVIATION("Best performance: ",
                           (result.IterationsPerSecondMaximum()),
                           (result.IterationsPerSecondAverage()),
-                          "iter/s");
+                          "iterations/s");
             PAD_DEVIATION("Worst performance: ",
                           (result.IterationsPerSecondMinimum()),
                           (result.IterationsPerSecondAverage()),
-                          "iter/s");
+                          "iterations/s");
             PAD("Median performance: "
-		<< result.IterationsPerSecondMedian() << " iter/s "
+		<< result.IterationsPerSecondMedian() << " iterations/s "
 		<< "(" << Console::TextCyan << " "
 		<< result.IterationsPerSecondQuartile1() << " | "
 		<< result.IterationsPerSecondQuartile3() << " "
-		<< Console::TextDefault << ")"
-		);
+		<< Console::TextDefault << ")");
 
 #undef PAD_DEVIATION_INVERSE
 #undef PAD_DEVIATION

--- a/src/hayai_console_outputter.hpp
+++ b/src/hayai_console_outputter.hpp
@@ -182,23 +182,33 @@ namespace hayai
                     << Console::TextDefault
                     << "       Average time: "
                     << std::setprecision(3)
-                    << result.RunTimeAverage() / 1000.0 << " us"
+                    << result.RunTimeAverage() / 1000.0 << " us "
+                    << "(" << Console::TextBlue << "~"
+                    << result.RunTimeStdDev() / 1000.0 << " us"
+                    << Console::TextDefault << ")"
                     << std::endl;
 
-            PAD_DEVIATION_INVERSE("Fastest: ",
+            PAD_DEVIATION_INVERSE("Fastest time: ",
                                   (result.RunTimeMinimum() / 1000.0),
                                   (result.RunTimeAverage() / 1000.0),
                                   "us");
-            PAD_DEVIATION_INVERSE("Slowest: ",
+            PAD_DEVIATION_INVERSE("Slowest time: ",
                                   (result.RunTimeMaximum() / 1000.0),
                                   (result.RunTimeAverage() / 1000.0),
                                   "us");
+            PAD("Median time: "
+		<< result.RunTimeMedian() / 1000.0 << " us "
+		<< "(" << Console::TextCyan << " "
+		<< result.RunTimeQuartile1() / 1000.0 << " | "
+		<< result.RunTimeQuartile3() / 1000.0 << " "
+		<< Console::TextDefault << ")"
+		);
 
             _stream << std::setprecision(5);
 
             PAD("");
             PAD("Average performance: " <<
-                result.RunsPerSecondAverage() << " runs/s");
+                result.RunsPerSecondAverage() << " runs/s " );
             PAD_DEVIATION("Best performance: ",
                           result.RunsPerSecondMaximum(),
                           result.RunsPerSecondAverage(),
@@ -207,37 +217,62 @@ namespace hayai
                           result.RunsPerSecondMinimum(),
                           result.RunsPerSecondAverage(),
                           "runs/s");
+            PAD("Median performance: "
+		<< result.RunsPerSecondMedian() << " runs/s "
+		<< "(" << Console::TextCyan << " "
+		<< result.RunsPerSecondQuartile1() << " | "
+		<< result.RunsPerSecondQuartile3() << " "
+		<< Console::TextDefault << ")"
+		);
 
+            PAD("");
             _stream << Console::TextBlue << "[ITERATIONS] "
                     << Console::TextDefault
                     << std::setprecision(3)
                     << "       Average time: "
-                    << result.IterationTimeAverage() / 1000.0 << " us"
+                    << result.IterationTimeAverage() / 1000.0 << " us "
+		    << "(" << Console::TextBlue << "~"
+		    << result.IterationTimeStdDev() / 1000.0 << " us"
+		    << Console::TextDefault << ")"
                     << std::endl;
 
-            PAD_DEVIATION_INVERSE("Fastest: ",
+            PAD_DEVIATION_INVERSE("Fastest time: ",
                                   (result.IterationTimeMinimum() / 1000.0),
                                   (result.IterationTimeAverage() / 1000.0),
                                   "us");
-            PAD_DEVIATION_INVERSE("Slowest: ",
+            PAD_DEVIATION_INVERSE("Slowest time: ",
                                   (result.IterationTimeMaximum() / 1000.0),
                                   (result.IterationTimeAverage() / 1000.0),
                                   "us");
+            PAD("Median time: "
+		<< result.IterationTimeMedian() / 1000.0 << " us "
+		<< "(" << Console::TextCyan << " "
+		<< result.IterationTimeQuartile1() / 1000.0 << " | "
+		<< result.IterationTimeQuartile3() / 1000.0 << " "
+		<< Console::TextDefault << ")"
+		);
 
             _stream << std::setprecision(5);
 
             PAD("");
             PAD("Average performance: " <<
                 result.IterationsPerSecondAverage() <<
-                " iterations/s");
+                " iter/s " );
             PAD_DEVIATION("Best performance: ",
                           (result.IterationsPerSecondMaximum()),
                           (result.IterationsPerSecondAverage()),
-                          "iterations/s");
+                          "iter/s");
             PAD_DEVIATION("Worst performance: ",
                           (result.IterationsPerSecondMinimum()),
                           (result.IterationsPerSecondAverage()),
-                          "iterations/s");
+                          "iter/s");
+            PAD("Median performance: "
+		<< result.IterationsPerSecondMedian() << " iter/s "
+		<< "(" << Console::TextCyan << " "
+		<< result.IterationsPerSecondQuartile1() << " | "
+		<< result.IterationsPerSecondQuartile3() << " "
+		<< Console::TextDefault << ")"
+		);
 
 #undef PAD_DEVIATION_INVERSE
 #undef PAD_DEVIATION

--- a/src/hayai_json_outputter.hpp
+++ b/src/hayai_json_outputter.hpp
@@ -165,9 +165,28 @@ namespace hayai
             _stream <<
                 JSON_ARRAY_END;
 
+	    dumpProperty( "mean", result.RunTimeAverage() );
+	    dumpProperty( "stddev", result.RunTimeStdDev() );
+	    dumpProperty( "median", result.RunTimeMedian() );
+	    dumpProperty( "quartile1", result.RunTimeQuartile1() );
+	    dumpProperty( "quartile3", result.RunTimeQuartile3() );
+
             EndTestObject();
         }
     private:
+	void dumpProperty( const std::string& key, const double value )
+	{
+	    _stream
+                << JSON_VALUE_SEPARATOR
+		<< JSON_STRING_BEGIN
+		<< key
+		<< JSON_STRING_END
+		<< JSON_NAME_SEPARATOR
+		<< std::fixed
+		<< std::setprecision(6)
+		<< (value / 1000000.0);
+	}
+
         void BeginTestObject(const std::string& fixtureName,
                              const std::string& testName,
                              const TestParametersDescriptor& parameters,

--- a/src/hayai_test_result.hpp
+++ b/src/hayai_test_result.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <stdexcept>
 #include <limits>
+#include <cmath>
 
 #include "hayai_clock.hpp"
 
@@ -25,7 +26,9 @@ namespace hayai
                 _iterations(iterations),
                 _timeTotal(0),
                 _timeRunMin(std::numeric_limits<uint64_t>::max()),
-                _timeRunMax(std::numeric_limits<uint64_t>::min())
+                _timeRunMax(std::numeric_limits<uint64_t>::min()),
+                _timeStdDev(0.0),
+                _timeMedian(0.0)
         {
             // Summarize under the assumption of values being accessed more
             // than once.
@@ -43,6 +46,54 @@ namespace hayai
 
                 ++runIt;
             }
+
+	    const double mean = RunTimeAverage();
+	    double accu = 0.0;
+
+	    runIt = _runTimes.begin();
+
+	    while (runIt != _runTimes.end())
+            {
+                const uint64_t run = *runIt;
+		const double diff = double(run) - mean;
+		accu += (diff * diff);
+
+                ++runIt;
+            }
+
+	    _timeStdDev = std::sqrt( accu / (_runTimes.size()-1));
+
+	    std::vector<uint64_t> sortedRunTimes( _runTimes );
+	    std::sort( sortedRunTimes.begin(), sortedRunTimes.end() );
+
+	    const uint64_t sortedSize = sortedRunTimes.size();
+	    const uint64_t sortedSizeHalf = sortedSize / 2;
+	    if (sortedSize >= 2)
+	    {
+		const uint64_t quartile = sortedSizeHalf / 2;
+		if ((sortedSize % 2) == 0)
+		{
+		    _timeMedian =
+			(double(sortedRunTimes[sortedSizeHalf-1])
+			 + double(sortedRunTimes[sortedSizeHalf]) ) / 2;
+
+		    _timeQuartile1 =
+			double(sortedRunTimes[quartile]);
+		    _timeQuartile3 =
+			double(sortedRunTimes[sortedSizeHalf+quartile]);
+		}
+		else
+		{
+		    _timeMedian = double(sortedRunTimes[sortedSizeHalf]);
+
+		    _timeQuartile1 =
+			(double(sortedRunTimes[quartile-1])
+			 + double(sortedRunTimes[quartile]) ) / 2;
+		    _timeQuartile3 =
+			(double(sortedRunTimes[sortedSizeHalf+(quartile-1)])
+			 + double(sortedRunTimes[sortedSizeHalf+quartile]) ) / 2;
+		}
+	    }
         }
 
 
@@ -66,6 +117,29 @@ namespace hayai
             return double(_timeTotal) / double(_runTimes.size());
         }
 
+        /// Standard deviation time per run.
+        inline double RunTimeStdDev() const
+        {
+	    return _timeStdDev;
+        }
+
+        /// Median (2nd Quartile) time per run.
+        inline double RunTimeMedian() const
+        {
+	    return _timeMedian;
+        }
+
+        /// 1st Quartile time per run.
+        inline double RunTimeQuartile1() const
+        {
+	    return _timeQuartile1;
+        }
+
+        /// 3rd Quartile time per run.
+        inline double RunTimeQuartile3() const
+        {
+	    return _timeQuartile3;
+        }
 
         /// Maximum time per run.
         inline double RunTimeMaximum() const
@@ -87,6 +161,23 @@ namespace hayai
             return 1000000000.0 / RunTimeAverage();
         }
 
+        /// Median (2nd Quartile) runs per second.
+        inline double RunsPerSecondMedian() const
+        {
+            return 1000000000.0 / RunTimeMedian();
+        }
+
+        /// 1st Quartile runs per second.
+        inline double RunsPerSecondQuartile1() const
+        {
+            return 1000000000.0 / RunTimeQuartile1();
+        }
+
+        /// 3rd Quartile runs per second.
+        inline double RunsPerSecondQuartile3() const
+        {
+            return 1000000000.0 / RunTimeQuartile3();
+        }
 
         /// Maximum runs per second.
         inline double RunsPerSecondMaximum() const
@@ -108,6 +199,29 @@ namespace hayai
             return RunTimeAverage() / double(_iterations);
         }
 
+        /// Standard deviation time per iteration.
+        inline double IterationTimeStdDev() const
+        {
+            return RunTimeStdDev() / double(_iterations);
+        }
+
+        /// Median (2nd Quartile) time per iteration.
+        inline double IterationTimeMedian() const
+        {
+            return RunTimeMedian() / double(_iterations);
+        }
+
+        /// 1st Quartile time per iteration.
+        inline double IterationTimeQuartile1() const
+        {
+            return RunTimeQuartile1() / double(_iterations);
+        }
+
+        /// 3rd Quartile time per iteration.
+        inline double IterationTimeQuartile3() const
+        {
+            return RunTimeQuartile3() / double(_iterations);
+        }
 
         /// Minimum time per iteration.
         inline double IterationTimeMinimum() const
@@ -129,6 +243,23 @@ namespace hayai
             return 1000000000.0 / IterationTimeAverage();
         }
 
+        /// Median (2nd Quartile) iterations per second.
+        inline double IterationsPerSecondMedian() const
+        {
+            return 1000000000.0 / IterationTimeMedian();
+        }
+
+        /// 1st Quartile iterations per second.
+        inline double IterationsPerSecondQuartile1() const
+        {
+            return 1000000000.0 / IterationTimeQuartile1();
+        }
+
+        /// 3rd Quartile iterations per second.
+        inline double IterationsPerSecondQuartile3() const
+        {
+            return 1000000000.0 / IterationTimeQuartile3();
+        }
 
         /// Minimum iterations per second.
         inline double IterationsPerSecondMinimum() const
@@ -148,6 +279,10 @@ namespace hayai
         uint64_t _timeTotal;
         uint64_t _timeRunMin;
         uint64_t _timeRunMax;
+        double _timeStdDev;
+        double _timeMedian;
+        double _timeQuartile1;
+        double _timeQuartile3;
     };
 }
 #endif

--- a/src/hayai_test_result.hpp
+++ b/src/hayai_test_result.hpp
@@ -61,7 +61,7 @@ namespace hayai
                 ++runIt;
             }
 
-	    _timeStdDev = std::sqrt( accu / (_runTimes.size()-1));
+	    _timeStdDev = std::sqrt(accu / (_runTimes.size() - 1));
 
 	    std::vector<uint64_t> sortedRunTimes( _runTimes );
 	    std::sort( sortedRunTimes.begin(), sortedRunTimes.end() );
@@ -74,24 +74,24 @@ namespace hayai
 		if ((sortedSize % 2) == 0)
 		{
 		    _timeMedian =
-			(double(sortedRunTimes[sortedSizeHalf-1])
-			 + double(sortedRunTimes[sortedSizeHalf]) ) / 2;
+			(double(sortedRunTimes[sortedSizeHalf - 1])
+			 + double(sortedRunTimes[sortedSizeHalf])) / 2;
 
 		    _timeQuartile1 =
 			double(sortedRunTimes[quartile]);
 		    _timeQuartile3 =
-			double(sortedRunTimes[sortedSizeHalf+quartile]);
+			double(sortedRunTimes[sortedSizeHalf + quartile]);
 		}
 		else
 		{
 		    _timeMedian = double(sortedRunTimes[sortedSizeHalf]);
 
 		    _timeQuartile1 =
-			(double(sortedRunTimes[quartile-1])
-			 + double(sortedRunTimes[quartile]) ) / 2;
+			(double(sortedRunTimes[quartile - 1])
+			 + double(sortedRunTimes[quartile])) / 2;
 		    _timeQuartile3 =
-			(double(sortedRunTimes[sortedSizeHalf+(quartile-1)])
-			 + double(sortedRunTimes[sortedSizeHalf+quartile]) ) / 2;
+			(double(sortedRunTimes[sortedSizeHalf + (quartile - 1)])
+			 + double(sortedRunTimes[sortedSizeHalf + quartile])) / 2;
 		}
 	    }
         }


### PR DESCRIPTION
The test report only contains simple statistical values, I've added besides the `average`, `min` and `max` the following calculations:

- `StdDev` ... standard deviation
- `Median` ... the median value aka. 2nd quartile
- `Quartile1` ... the 1st quartile value
- `Quartile3` ... the 3rd quartile value
 
This new values are integrated in console and JSON output implementation. An working example output can be seen in the succeeded travis-ci report under https://travis-ci.org/ppaulweber/libhayai/jobs/227349955#L424
