### PR TITLE
Use shuffle instead of random_shuffle.

### DIFF
--- a/src/hayai_benchmarker.hpp
+++ b/src/hayai_benchmarker.hpp
@@ -4,6 +4,9 @@
 #include <vector>
 #include <limits>
 #include <iomanip>
+#if __cplusplus > 201100L
+#include <random>
+#endif
 #include <string>
 #include <cstring>
 
@@ -300,8 +303,16 @@ namespace hayai
         static void ShuffleTests()
         {
             Benchmarker& instance = Instance();
+#if __cplusplus > 201100L
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(instance._tests.begin(),
+                         instance._tests.end(),
+                         g);
+#else
             std::random_shuffle(instance._tests.begin(),
                                 instance._tests.end());
+#endif
         }
     private:
         /// Calibration model.


### PR DESCRIPTION
Random_shuffle is deprecated in C++14, and was removed in C++17.