### PR TITLE
Fixed the tests with C++11 or newer, and extended the travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,30 @@ matrix:
         - COMPILER=clang++
         - BUILD_TYPE=Release
         - EXTRA_FLAGS="-Weverything -Wno-weak-vtables -Wno-global-constructors -Wno-exit-time-destructors -Wno-padded"
+    - os: linux
+      compiler: clang
+      env:
+        - COMPILER=clang++
+        - BUILD_TYPE=Release
+        - EXTRA_FLAGS="-std=c++11 -Weverything -Wno-weak-vtables -Wno-global-constructors -Wno-exit-time-destructors -Wno-padded -Wno-breserved-id-macro -Wno-zero-as-null-pointer-constant"
+    - os: linux
+      compiler: clang
+      env:
+        - COMPILER=clang++
+        - BUILD_TYPE=Release
+        - EXTRA_FLAGS="-std=c++14 -Weverything -Wno-weak-vtables -Wno-global-constructors -Wno-exit-time-destructors -Wno-padded -Wno-reserved-id-macro -Wno-zero-as-null-pointer-constant"
+    - os: linux
+      compiler: clang
+      env:
+        - COMPILER=clang++
+        - BUILD_TYPE=Release
+        - EXTRA_FLAGS="-std=c++17 -Weverything -Wno-weak-vtables -Wno-global-constructors -Wno-exit-time-destructors -Wno-padded -Wno-reserved-id-macro -Wno-zero-as-null-pointer-constant"
+    - os: linux
+      compiler: clang
+      env:
+        - COMPILER=clang++
+        - BUILD_TYPE=Release
+        - EXTRA_FLAGS="-stdlib=libc++ -std=c++17 -Weverything -Wno-weak-vtables -Wno-global-constructors -Wno-exit-time-destructors -Wno-padded -Wno-reserved-id-macro -Wno-zero-as-null-pointer-constant"
 
 before_install:
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
@@ -47,6 +71,7 @@ before_script:
 
 script:
   - export CXXFLAGS="${EXTRA_FLAGS}"
+  - export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/clang-5.0.0/lib"
   - cmake -DCMAKE_CXX_COMPILER=${COMPILER} -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DTEST=ON ..
   - make VERBOSE=1
   - DESTDIR=install_tmp make install

--- a/tests/hayai_test_parameter_descriptor.cpp
+++ b/tests/hayai_test_parameter_descriptor.cpp
@@ -52,7 +52,7 @@ void ExpectTestParameterDescriptorParameterDescriptors(
             msg << actual[j];
         }
 
-        ADD_FAILURE() << msg;
+        ADD_FAILURE() << msg.str();
     }
     else if (i < expected.size())
     {
@@ -66,7 +66,7 @@ void ExpectTestParameterDescriptorParameterDescriptors(
             msg << expected[j];
         }
 
-        ADD_FAILURE() << msg;
+        ADD_FAILURE() << msg.str();
     }
 }
 


### PR DESCRIPTION
Currently the build with clang, std=c++17 and libcxx fails, which is addressed by my other PR.

I also disabled two warnings in these builds, one is the c++11+ specific null-nullptr warning, the other is about marco names strarting with two underscores.