### PR TITLE
Fixes target_include_directories missing for FetchContent/ExternalProject

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,12 @@ add_library(hayai_main
   hayai_posix_main.cpp
 )
 
+target_include_directories(hayai_main
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}/hayai>
+)
+
 set_target_properties(hayai_main PROPERTIES
   PUBLIC_HEADER "${hayai_headers}"
 )


### PR DESCRIPTION
When trying to get Hayai with CMake FetchContent, project was unable to find hayai.hpp.

Fixes this issue by added include directory CMake command for hayai_main target.